### PR TITLE
Monatliche Sitzungen

### DIFF
--- a/go.tex
+++ b/go.tex
@@ -107,7 +107,7 @@ Der Vorstand ist beschlussfähig, wenn mindestens die Hälfte seiner Mitglieder 
 Der Vorstand stellt die vorläufige Tagesordnung auf. Erster Tagesordnungspunkt ist die Feststellung der mit der Einladung versandten vorläufigen Tagesordnung. Zu Beginn der Sitzung können auf Antrag zusätzliche Tagesordnungspunkte aufgenommen werden.
 
 Die Vorsitzende bzw. der Vorsitzende des Vorstands beruft die Sitzungen des Konvents ein.
-Der Konvent tagt in der Regel vier mal pro Semester. Eine außerordentliche Sitzung ist einzuberufen, wenn mindestens ein Drittel aller Mitglieder des Konvents dies verlangt. Die Einladung soll den Mitgliedern spätestens eine Woche vor der Sitzung vorliegen. Ein Versand per E-Mail ist ausreichend. Mit der Einladung ist eine vorläufige Tagesordnung zu versenden.
+Der Konvent tagt in der Regel monatlich. Eine außerordentliche Sitzung ist einzuberufen, wenn mindestens ein Drittel aller Mitglieder des Konvents dies verlangt. Die Einladung soll den Mitgliedern spätestens eine Woche vor der Sitzung vorliegen. Ein Versand per E-Mail ist ausreichend. Mit der Einladung ist eine vorläufige Tagesordnung zu versenden.
 
 Die Vorsitzende bzw. der Vorsitzende oder einer ihrer bzw. seiner Stellvertreterinnen bzw. Stellvertreter leitet die Sitzungen.	
 


### PR DESCRIPTION
Aktueller Vorstand für den Konvent Informatik. Passt zu den Gremiensitzungen.
Vier mal pro Semester sollte reichen um sich vor/nach dem Fakrat zu treffen. Monatlich erlaubt regulärere Termine (jeden ersten Montag im Monat).
