### PR TITLE
Gendering generisches Femininum

### DIFF
--- a/go.tex
+++ b/go.tex
@@ -61,38 +61,30 @@
 \tableofcontents
 % \newpage
 
-
-%
-% Präambel
-%
-
- % Aus Gründen der besseren Lesbarkeit wird ausschließlich die männliche Form verwendet. Dabei ist jede andere Form impliziert. Die Geschlechtsdefinition obliegt jeder Person selbst.
-
-
+Aus Gründen der besseren Lesbarkeit wird ausschließlich die weibliche Form verwendet. Dabei ist jede andere Form impliziert. Die Geschlechtsdefinition obliegt jeder Person selbst.
 
 \Paragraph{title = Mitglieder}
 
-Mitglieder des Konvents sind alle von der KIT-Fakultät für Physik zur Promotion angenommenen Doktorandinnen und Doktoranden. 
+Mitglieder des Konvents sind alle von der KIT-Fakultät für Physik zur Promotion angenommenen Doktorandinnen. 
 
 \Paragraph{title = Aufgaben}%
 \label{aufgaben}
 
-Der Konvent der Doktorandinnen und Doktoranden ist die gemäß § 38 Absatz 7 Landeshochschulgesetz (LHG) gebildete Interessenvertretung der Doktorandinnen und Doktoranden des Karlsruher Institut für Technologie (KIT). Der Konvent ist die Basis für den Dialog zwischen den Organen des KIT und den Doktorandinnen und Doktoranden. Der Konvent berät die die Doktorandinnen und Doktoranden betreffenden Fragen und spricht Empfehlungen an die Organe des KIT aus. Entwürfe für Promotionsordnungen werden dem Konvent zur Stellungnahme zugeleitet. Der Konvent stimmt sich bei Fragen, die Doktorandinnen und Doktoranden KIT-weit betreffen, mit den anderen Konventen ab.
-
+Der Konvent der Doktorandinnen ist die gemäß § 38 Absatz 7 Landeshochschulgesetz (LHG) gebildete Interessenvertretung der Doktorandinnen des Karlsruher Institut für Technologie (KIT). Der Konvent ist die Basis für den Dialog zwischen den Organen des KIT und den Doktorandinnen. Der Konvent berät die die Doktorandinnen betreffenden Fragen und spricht Empfehlungen an die Organe des KIT aus. Entwürfe für Promotionsordnungen werden dem Konvent zur Stellungnahme zugeleitet. Der Konvent stimmt sich bei Fragen, die Doktorandinnen KIT-weit betreffen, mit den anderen Konventen ab.
 
 \Paragraph{title = Vorstand}
 
 Der Vorstand des Konvents besteht aus
 \begin{enumerate}
-	\item einer Vorsitzenden bzw. einem Vorsitzendem,
-	\item einer stellvertretenden Vorsitzenden bzw. einem stellvertretenden Vorsitzenden,
-	\item eine Sprecherin bzw. ein Sprecher,
-	\item eine stellvertretende Sprecherin bzw. ein stellvertretender Sprecher,
+	\item einer Vorsitzenden,
+	\item einer stellvertretenden Vorsitzenden,
+	\item eine Sprecherin,
+	\item eine stellvertretende Sprecherin,
 	\item zwei Beisitzern.
 \end{enumerate}
-Die Sprecherin bzw. der Sprecher nimmt als Gast an den Sitzungen des Fakultätsrats teil und
+Die Sprecherin nimmt als Gast an den Sitzungen des Fakultätsrats teil und
 kann sich durch andere Mitglieder des Vorstands vertreten lassen.
-Die Sprecherinnen bzw. Sprecher sind zudem für den Kontakt mit den anderen KIT Doktorandenkonventen und weiteren Organisationen im und außerhalb des KIT zuständig. Sie sind befugt, in diesen Zusammenhängen im Namen des Konvents zu sprechen und abzustimmen.
+Die Sprecherinnen sind zudem für den Kontakt mit den anderen KIT Doktorandenkonventen und weiteren Organisationen im und außerhalb des KIT zuständig. Sie sind befugt, in diesen Zusammenhängen im Namen des Konvents zu sprechen und abzustimmen.
 
 \label{wahl}
 Die Mitglieder des Vorstands werden von den anwesenden Mitgliedern des Konvents gewählt. Für jede Wahl hat jedes Konventsmitglied eine Stimme.Gewählt sind jeweils die Personen, die die meisten Stimmen auf sich vereinen können. Bei Stimmengleichheit entscheidet das Los. Die Wiederwahl der Vorstandsmitglieder ist zulässig.
@@ -106,17 +98,17 @@ Der Vorstand ist beschlussfähig, wenn mindestens die Hälfte seiner Mitglieder 
 \Paragraph{title = Sitzungen}
 Der Vorstand stellt die vorläufige Tagesordnung auf. Erster Tagesordnungspunkt ist die Feststellung der mit der Einladung versandten vorläufigen Tagesordnung. Zu Beginn der Sitzung können auf Antrag zusätzliche Tagesordnungspunkte aufgenommen werden.
 
-Die Vorsitzende bzw. der Vorsitzende des Vorstands beruft die Sitzungen des Konvents ein.
+Die Vorsitzende des Vorstands beruft die Sitzungen des Konvents ein.
 Der Konvent tagt in der Regel vier mal pro Semester. Eine außerordentliche Sitzung ist einzuberufen, wenn mindestens ein Drittel aller Mitglieder des Konvents dies verlangt. Die Einladung soll den Mitgliedern spätestens eine Woche vor der Sitzung vorliegen. Ein Versand per E-Mail ist ausreichend. Mit der Einladung ist eine vorläufige Tagesordnung zu versenden.
 
-Die Vorsitzende bzw. der Vorsitzende oder einer ihrer bzw. seiner Stellvertreterinnen bzw. Stellvertreter leitet die Sitzungen.	
+Die Vorsitzende oder ihre Stellvertreterin leitet die Sitzungen.	
 
 Der Konvent tagt in der Regel nichtöffentlich. Über die KIT-Öffentlichkeit einer Sitzung sowie das Hinzuziehen von Gästen beschließt der Konvent mit der einfachen Mehrheit seiner anwesenden Mitglieder.
 
 Über die Sitzungen des Konvents wird ein Protokoll erstellt.
 
 \Paragraph{title = Beschlussfassung}
-Der Konvent ist beschlussfähig, wenn 7 seiner Mitglieder anwesend sind. Die Sitzungsleiterin bzw. der Sitzungsleiter stellt die Beschlussfähigkeit fest.	
+Der Konvent ist beschlussfähig, wenn 7 seiner Mitglieder anwesend sind. Die Sitzungsleiterin stellt die Beschlussfähigkeit fest.
 
 Der Konvent fasst Beschlüsse mit der einfachen Mehrheit der anwesenden Mitglieder. Die Beschlussfassung erfolgt in der Regel durch Handzeichen. Auf Verlangen eines anwesenden Mitglieds ist ein Beschluss in geheimer Abstimmung zu fassen. Entscheidungen in Personalangelegenheiten erfolgen grundsätzlich in geheimer Abstimmung.
 


### PR DESCRIPTION
Die Lesbarkeit leidet unter der weiblich+männlich Doppelnennung. Eines von beidem ist komplett ausreichend.
