### PR TITLE
Beschlussfassung über die Anzahl des zu wählenden Vorstands

### DIFF
--- a/go.tex
+++ b/go.tex
@@ -67,7 +67,7 @@ Der Konvent kommuniziert bei Fragen, die Doktorandinnen und Doktoranden KIT-weit
 
 Mitglieder des Konvents sind alle von der KIT-Fakultät für Physik zur Promotion angenommenen Doktorandinnen und Doktoranden. 
 
-\Paragraph{title = Vorstand}
+\Paragraph{title = Vorstand}\label{par:vorstand}
 
 Der Vorstand des Konvents besteht in der Regel aus insgesamt 5 Mitgliedern,
 nicht jedoch aus mehr als 5 oder weniger als 3 Mitgliedern.
@@ -82,8 +82,11 @@ Die Aufgaben des Vorstands sind:
 Der Vorstand ist befugt im Namen des Konvents zu sprechen und abzustimmen.
 Der Vorstand ist an die Beschlüsse des Konvents gebunden und leitet diese an Gremien weiter.
 
-Die Mitglieder des Vorstands werden von den anwesenden Mitgliedern des Konvents gewählt. Für
-die Wahl hat jedes Konventsmitglied Stimmen entsprechend der Anzahl der Vorstandsmitglieder. Stimmen können nicht kumuliert werden.
+Die Mitglieder des Vorstands werden von den anwesenden Mitgliedern des Konvents gewählt. 
+Zuvor beschließt der Konvent gemäß
+\ref{par:beschlussfassung}\refPar{par:beschlussfassung:satz:beschlussfassung} über die Mitgliederanzahl des 
+Vorstandes der bevorstehenden Amtsperiode.
+Für die Wahl hat jedes Konventsmitglied Stimmen entsprechend der Anzahl der Vorstandsmitglieder. Stimmen können nicht kumuliert werden.
 Gewählt sind die Personen, die die meisten Stimmen auf sich vereinen können. Bei Stimmengleichheit entscheidet das Los. Die Wiederwahl der Vorstandsmitglieder ist zulässig.
 Der Vorstand wählt mit einfacher Mehrheit der Stimmen aus seiner Mitte eine Vorsitzende bzw.
 einen Vorsitzenden sowie eine Stellvertreterin bzw.\ einen Stellvertreter.
@@ -99,7 +102,7 @@ Für die Beschlussfassung genügt die einfache Mehrheit der anwesenden Vorstands
 
 \Paragraph{title = Sitzungen}
 Der Konvent tagt in der Regel einmal pro Semester. 
-Eine außerordentliche Sitzung ist einzuberufen, wenn mindestens 10\% aller Mitglieder oder die Hälfte des Vorstands des Konvents dies verlangt.
+Eine außerordentliche Sitzung ist einzuberufen, wenn mindestens 10\,\% aller Mitglieder oder die Hälfte des Vorstands des Konvents dies verlangt.
 Die Vorsitzende bzw.\ der Vorsitzende des Vorstands beruft die Sitzungen des Konvents ein.
 Die Einladung soll den Mitgliedern spätestens eine Woche vor der Sitzung vorliegen. Ein Versand per E-Mail ist ausreichend. Mit der Einladung ist eine vorläufige Tagesordnung zu versenden.
 
@@ -115,15 +118,16 @@ Der Konvent kann Arbeitsgruppen einsetzen, die zwischen den Sitzungen des Konven
 und den Sitzungen des Konvents berichten.
 Jeder Arbeitsgruppe soll ein Mitglied des Vorstands angehören.
 
-\Paragraph{title = Beschlussfassung}
+\Paragraph{title = Beschlussfassung}\label{par:beschlussfassung}
 Der Konvent ist beschlussfähig, wenn 11 seiner Mitglieder anwesend sind. Die Sitzungsleiterin bzw.\ der Sitzungsleiter stellt die Beschlussfähigkeit fest.	
 
 Der Konvent fasst Beschlüsse mit der einfachen Mehrheit der anwesenden Mitglieder. Die
 Beschlussfassung erfolgt in der Regel durch Handzeichen. Auf Verlangen eines
 anwesenden Mitglieds ist ein Beschluss in geheimer Abstimmung zu fassen. 
 Entscheidungen in Personalangelegenheiten erfolgen grundsätzlich in geheimer Abstimmung.
+\label{par:beschlussfassung:satz:beschlussfassung}
 
-\Paragraph{title = Änderung der Geschäftsordnung}
+\Paragraph{title = Änderung der Geschäftsordnung}\label{par:aenderung_der_go}
 Änderungsanträge zur Geschäftsordnung müssen mit der Einladung angekündigt werden. Sie
 bedürfen eines Beschlusses mit 2/3 Mehrheit aller anwesenden Mitglieder des Konvents.
 


### PR DESCRIPTION
* Es wurde angemerkt, dass vor der Wahl erst genau bekannt sein muss,
was gewählt wird, sprich wie viele Personen in den Vorstand gewählt
werden sollen.
* Es wird ein Beschluss über die Anzahl des zukünftigen Vorstands
gefällt und dann kann dieser gewählt werden.

* Fix Typo